### PR TITLE
[CHECKED_BOX] include checkedDecisionFunc in TableData construction, …

### DIFF
--- a/electron/scripts/flagged_notes.js
+++ b/electron/scripts/flagged_notes.js
@@ -75,7 +75,16 @@ function constructTable() {
     let fieldNames = ["href", "href", "checkboxFuncKey", "note_type",
         "child_english_name", "caregiver_english_name", "note"];
     let columnData = new ColumnData(headers, columnTypes, fieldNames);
-    let tdata = new TableData("flagged_notes_table", columnData, g_table_entries);
+    let checkDecision = function(row_json) {
+        let row_obj = JSON.parse(row_json)
+        if (row_obj.child_id == 1) {
+            console.log(row_obj)
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+    let tdata = new TableData("flagged_notes_table", columnData, g_table_entries, checkDecision);
     generateTable(tdata);
 }
 

--- a/electron/scripts/flagged_notes.js
+++ b/electron/scripts/flagged_notes.js
@@ -75,15 +75,7 @@ function constructTable() {
     let fieldNames = ["href", "href", "checkboxFuncKey", "note_type",
         "child_english_name", "caregiver_english_name", "note"];
     let columnData = new ColumnData(headers, columnTypes, fieldNames);
-    let checkDecision = function(row_json) {
-        let row_obj = JSON.parse(row_json)
-        if (row_obj.child_id == 1) {
-            console.log(row_obj)
-            return 1;
-        } else {
-            return 0;
-        }
-    }
+    let checkDecision = function(row_obj) { return row_obj.child_id == 1 }
     let tdata = new TableData("flagged_notes_table", columnData, g_table_entries, checkDecision);
     generateTable(tdata);
 }

--- a/electron/scripts/lib.js
+++ b/electron/scripts/lib.js
@@ -106,7 +106,7 @@ function generateTable(tdata) {
                 input.type = "checkbox";
                 input.setAttribute("onchange", "" + cellData + "(this, " + rowIdx + ", " + JSON.stringify(obj).replace(/"/g, "'") + ")");
                 if (typeof tdata.checkedDecisionFunc != 'undefined') {
-                    input.checked = tdata.checkedDecisionFunc(JSON.stringify(obj))
+                    input.checked = tdata.checkedDecisionFunc(obj)
                 }
                 td.appendChild(input);
             } else {

--- a/electron/scripts/lib.js
+++ b/electron/scripts/lib.js
@@ -30,7 +30,7 @@ function ColumnData(headerList, columnTypeList, fieldNameList) {
         columnType: columnTypeList,
 
         // List of names of the fields to be extracted from the data object for this column.
-        fieldName: fieldNameList,
+        fieldName: fieldNameList
     }
 }
 

--- a/electron/scripts/lib.js
+++ b/electron/scripts/lib.js
@@ -30,12 +30,12 @@ function ColumnData(headerList, columnTypeList, fieldNameList) {
         columnType: columnTypeList,
 
         // List of names of the fields to be extracted from the data object for this column.
-        fieldName: fieldNameList
+        fieldName: fieldNameList,
     }
 }
 
 // TableData Class. An instance of this class is passed to tableGenerator() to construct a table.
-function TableData(id, columns, objects) {
+function TableData(id, columns, objects, checkedDecision) {
     return {
         // ID of the table in the HTML. 
         // Table should be defined in HTML but have no elements within.
@@ -49,7 +49,11 @@ function TableData(id, columns, objects) {
         // construct a row of the table. One object per row.
         // Fields in these objects should have names matching the "fieldName" 
         // element of the ColumnData objects.
-        tableElementObjects: objects
+        tableElementObjects: objects,
+
+        // if a checkbox is included, this function should return true if the box should
+        // be checked on window load, false otherwise
+        checkedDecisionFunc: checkedDecision
     }
 }
 
@@ -101,6 +105,9 @@ function generateTable(tdata) {
                 let input = document.createElement("input");
                 input.type = "checkbox";
                 input.setAttribute("onchange", "" + cellData + "(this, " + rowIdx + ", " + JSON.stringify(obj).replace(/"/g, "'") + ")");
+                if (typeof tdata.checkedDecisionFunc != 'undefined') {
+                    input.checked = tdata.checkedDecisionFunc(JSON.stringify(obj))
+                }
                 td.appendChild(input);
             } else {
                 console.error("Unknown column type in generateTable: " + type);


### PR DESCRIPTION
…pet example in flagged notes -- child_id == 1 results in checked box at load

Take a look at this idea for enabling checked/unchecked check boxes at load. The idea is to define a checkedDecisionFunc which is passed into the TableData constructor. The checkedDecisionFunc takes a table row object (gets this from generateTable in lib.js) and it can use this obj to decide whether or not the box should be checked or unchecked at load. If it returns something that evaluates to true, the box will checked, something that evaluates to false, the box will be unchecked.

Let me know if yall want to move forward with this methodology or want to change something or want to scrap it entirely.