### PR TITLE
filter on Unkown status when Create New button clicked in Child List

### DIFF
--- a/fss/src/app/children/child-list.component.ts
+++ b/fss/src/app/children/child-list.component.ts
@@ -44,6 +44,7 @@ export class ChildList implements OnInit, OnChanges {
         let new_child = new Child(null);
         new_child.child_pinyin_name = "New Child";
         this.restService.addChild(new_child).then(the_child => this.onSelect(the_child));
+        this.filterUnknown = true;
     }
 
     isSelected(child): boolean {


### PR DESCRIPTION
This change ensures that new children are immediately viewable in the child list when creating new children. The old behavior made the user toggle the Unkown filter switch manually